### PR TITLE
Change source of yamerl so the project builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ dep_mixer = git https://github.com/opscode/mixer.git master
 dep_sync = git https://github.com/rustyio/sync.git master
 dep_colorerl = git https://github.com/unbalancedparentheses/colorerl.git master
 dep_thorerl = git https://github.com/unbalancedparentheses/thorerl.git master
-dep_yamerl = git https://github.com/unbalancedparentheses/yamerl.git master
+dep_yamerl = git https://github.com/yakaz/yamerl.git master
 
 include erlang.mk
 


### PR DESCRIPTION
I've seen #108 but still think it's not bad to keep this repo usable as long as the go version is not available. Hence, the PR.